### PR TITLE
RFC: Add CODEOWNERS for main branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global rule, if anything matches after this then that rule takes precedent
+* @fossfreedom @BuddiesOfBudgie/best-buds


### PR DESCRIPTION
This PR adds a CODEOWNERS to be used against the main branch for the lifetime of the Mutter soft-fork.

It is **NOT** intended to be used to enforce or mandate blocking individuals for merge. Listings can / **SHOULD** be modified based on interest / desire for code reviews, and **SHOULD NOT** be considered exhaustive.