### PR TITLE
RFC: Add CODEOWNERS for v1

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global rule, if anything matches after this then that rule takes precedent
+* @serebit @BuddiesOfBudgie/best-buds


### PR DESCRIPTION
This PR adds a CODEOWNERS to be used against the v1 branch for its lifetime until merged with main.

It is **NOT** intended to be used to enforce or mandate blocking individuals for merge. Listings can / **SHOULD** be modified based on interest / desire for code reviews, and **SHOULD NOT** be considered exhaustive.