### PR TITLE
v1: Fix CI and add Fedora target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, pull_request]
 jobs:
   alpine:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,3 +13,21 @@ jobs:
         meson setup build
         meson compile -C build
       shell: alpine.sh {0}
+
+  fedora:
+    runs-on: ubuntu-latest
+    container: "registry.fedoraproject.org/fedora:rawhide"
+    steps:
+    - name: Install pre-requisites
+      run: |
+        dnf --assumeyes install gcc-c++ meson git-core \
+                                'pkgconfig(wayland-protocols)' \
+                                'pkgconfig(wayland-scanner)' \
+                                'pkgconfig(wayland-server)' \
+                                'pkgconfig(wlroots)' \
+                                'pkgconfig(xcb)' 'pkgconfig(xkbcommon)'
+    - uses: actions/checkout@v2
+    - name: Build magpie
+      run: |
+        meson setup build
+        meson compile -C build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: jirutka/setup-alpine@v1
       with:
         branch: edge
-        packages: build-base meson wlroots-dev wayland-dev wayland-protocols libdecor
+        packages: build-base meson wlroots-dev wayland-dev wayland-protocols libdecor git
     - run: |
         meson setup build
         meson compile -C build


### PR DESCRIPTION
This fixes the GitHub Actions configuration so that Alpine CI works and adds a Fedora Rawhide CI target to ensure a glibc target is included.