### PR TITLE
Add missing stdlib.h to fix build on GCC 14

### DIFF
--- a/src/wlr-wrap-start.hpp
+++ b/src/wlr-wrap-start.hpp
@@ -5,6 +5,7 @@ static_assert(0 == 1, "wlroots include wrap started and not ended");
 #define WLROOTS_INCLUDE_WRAP_STARTED
 
 #include <pthread.h>
+#include <stdlib.h>
 #include <wayland-server-core.h>
 
 #ifdef __clang__


### PR DESCRIPTION
Suggested-by: @fweimer