### PR TITLE
Add API replacing gsd-power's use of libgnome-rr

### DIFF
--- a/data/dbus-interfaces/org.gnome.Mutter.DisplayConfig.xml
+++ b/data/dbus-interfaces/org.gnome.Mutter.DisplayConfig.xml
@@ -210,11 +210,41 @@
         Returns the new value after rounding.
     -->
     <method name="ChangeBacklight">
+	  <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
       <arg name="serial" direction="in" type="u" />
       <arg name="output" direction="in" type="u" />
       <arg name="value" direction="in" type="i" />
       <arg name="new_value" direction="out" type="i" />
     </method>
+
+	    <!--
+	SetBacklight:
+	@serial: configuration serial
+	@connector: the connector name
+	@value: the new backlight value
+
+	Changes the backlight of @output to @value.
+    -->
+    <method name="SetBacklight">
+      <arg name="serial" direction="in" type="u" />
+      <arg name="connector" direction="in" type="s" />
+      <arg name="value" direction="in" type="i" />
+    </method>
+
+    <!--
+	Backlight:
+
+	A set of backlights. Each backlight is a dictionary with the following
+	entries. If an entry is only a connector, it means there is no way to
+	control it via this D-Bus interface.
+
+	  * 'connector' (s) - An associated monitor connector
+	  * 'active' (s) - True if the monitor is active
+	  * 'value' (i) - Current value (optional)
+
+	The initial 'u' is a serial number used when setting the backlight.
+    -->
+    <property name="Backlight" type="(uaa{sv})" access="read" />
 
     <!--
         GetCrtcGamma:
@@ -489,5 +519,12 @@
       <arg name="output" direction="in" type="u" />
       <arg name="ctm" direction="in" type="(ttttttttt)" />
     </method>
+
+	<!--
+	HasExternalmonitor:
+
+        True if there is an external monitor connected and activated.
+    -->
+    <property name="HasExternalMonitor" type="b" access="read" />
   </interface>
 </node>

--- a/src/backends/meta-monitor-manager-private.h
+++ b/src/backends/meta-monitor-manager-private.h
@@ -180,9 +180,6 @@ struct _MetaMonitorManager
  *
  * @set_power_save_mode: Sets the #MetaPowerSave mode (for all displays).
  *
- * @change_backlight: Changes the backlight intensity to the given value (in
- *   percent).
- *
  * @tiled_monitor_added: Should be called by a #MetaMonitor when it is created.
  *
  * @tiled_monitor_removed: Should be called by a #MetaMonitor when it is

--- a/src/backends/meta-monitor.c
+++ b/src/backends/meta-monitor.c
@@ -2211,3 +2211,62 @@ meta_monitor_set_privacy_screen_enabled (MetaMonitor  *monitor,
 
   return meta_output_set_privacy_screen_enabled (output, enabled, error);
 }
+
+
+gboolean
+meta_monitor_get_backlight_info (MetaMonitor *monitor,
+                                 int         *backlight_min,
+                                 int         *backlight_max)
+{
+  MetaOutput *main_output;
+  int value;
+
+  main_output = meta_monitor_get_main_output (monitor);
+  value = meta_output_get_backlight (main_output);
+  if (value >= 0)
+    {
+      const MetaOutputInfo *output_info = meta_output_get_info (main_output);
+      if (backlight_min)
+        *backlight_min = output_info->backlight_min;
+      if (backlight_max)
+        *backlight_max = output_info->backlight_max;
+      return TRUE;
+    }
+  else
+    {
+      return FALSE;
+    }
+}
+
+void
+meta_monitor_set_backlight (MetaMonitor *monitor,
+                            int          value)
+{
+  MetaMonitorPrivate *priv = meta_monitor_get_instance_private (monitor);
+  GList *l;
+
+  for (l = priv->outputs; l; l = l->next)
+    {
+      MetaOutput *output = l->data;
+
+      meta_output_set_backlight (output, value);
+    }
+}
+
+gboolean
+meta_monitor_get_backlight (MetaMonitor *monitor,
+                            int         *value)
+{
+  if (meta_monitor_get_backlight_info (monitor, NULL, NULL))
+    {
+      MetaOutput *main_output;
+
+      main_output = meta_monitor_get_main_output (monitor);
+      *value = meta_output_get_backlight (main_output);
+      return TRUE;
+    }
+  else
+    {
+      return FALSE;
+    }
+}

--- a/src/backends/meta-monitor.h
+++ b/src/backends/meta-monitor.h
@@ -309,4 +309,16 @@ size_t meta_monitor_get_gamma_lut_size (MetaMonitor *monitor);
 void meta_monitor_set_gamma_lut (MetaMonitor        *monitor,
                                  const MetaGammaLut *lut);
 
+META_EXPORT_TEST
+gboolean meta_monitor_get_backlight_info (MetaMonitor *monitor,
+                                          int         *backlight_min,
+                                          int         *backlight_max);
+
+void meta_monitor_set_backlight (MetaMonitor *monitor,
+                                 int          value);
+
+META_EXPORT_TEST
+gboolean meta_monitor_get_backlight (MetaMonitor *monitor,
+                                     int         *value);
+
 #endif /* META_MONITOR_H */

--- a/src/backends/meta-output.c
+++ b/src/backends/meta-output.c
@@ -35,6 +35,15 @@ enum
   N_PROPS
 };
 
+enum
+{
+  BACKLIGHT_CHANGED,
+
+  N_SIGNALS
+};
+
+static guint signals[N_SIGNALS];
+
 static GParamSpec *obj_props[N_PROPS];
 
 typedef struct _MetaOutputPrivate
@@ -200,7 +209,12 @@ meta_output_set_backlight (MetaOutput *output,
 {
   MetaOutputPrivate *priv = meta_output_get_instance_private (output);
 
+  g_return_if_fail (backlight >= priv->info->backlight_min);
+  g_return_if_fail (backlight <= priv->info->backlight_max);
+
   priv->backlight = backlight;
+
+  g_signal_emit (output, signals[BACKLIGHT_CHANGED], 0);
 }
 
 int
@@ -532,6 +546,15 @@ meta_output_class_init (MetaOutputClass *klass)
                         G_PARAM_CONSTRUCT_ONLY |
                         G_PARAM_STATIC_STRINGS);
   g_object_class_install_properties (object_class, N_PROPS, obj_props);
+
+  signals[BACKLIGHT_CHANGED] =
+    g_signal_new ("backlight-changed",
+                  G_TYPE_FROM_CLASS (klass),
+                  G_SIGNAL_RUN_LAST,
+                  0,
+                  NULL, NULL, NULL,
+                  G_TYPE_NONE, 0);
+
 }
 
 gboolean

--- a/src/backends/x11/meta-monitor-manager-xrandr.c
+++ b/src/backends/x11/meta-monitor-manager-xrandr.c
@@ -652,14 +652,6 @@ meta_monitor_manager_xrandr_apply_monitors_config (MetaMonitorManager      *mana
   return TRUE;
 }
 
-static void
-meta_monitor_manager_xrandr_change_backlight (MetaMonitorManager *manager,
-					      MetaOutput         *output,
-					      gint                value)
-{
-  meta_output_xrandr_change_backlight (META_OUTPUT_XRANDR (output), value);
-}
-
 static MetaMonitorXrandrData *
 meta_monitor_xrandr_data_from_monitor (MetaMonitor *monitor)
 {
@@ -966,7 +958,6 @@ meta_monitor_manager_xrandr_class_init (MetaMonitorManagerXrandrClass *klass)
   manager_class->ensure_initial_config = meta_monitor_manager_xrandr_ensure_initial_config;
   manager_class->apply_monitors_config = meta_monitor_manager_xrandr_apply_monitors_config;
   manager_class->set_power_save_mode = meta_monitor_manager_xrandr_set_power_save_mode;
-  manager_class->change_backlight = meta_monitor_manager_xrandr_change_backlight;
   manager_class->tiled_monitor_added = meta_monitor_manager_xrandr_tiled_monitor_added;
   manager_class->tiled_monitor_removed = meta_monitor_manager_xrandr_tiled_monitor_removed;
   manager_class->is_transform_handled = meta_monitor_manager_xrandr_is_transform_handled;

--- a/src/backends/x11/meta-output-xrandr.c
+++ b/src/backends/x11/meta-output-xrandr.c
@@ -190,41 +190,6 @@ meta_output_xrandr_apply_mode (MetaOutputXrandr *output_xrandr)
     }
 }
 
-static int
-normalize_backlight (MetaOutput *output,
-                     int         hw_value)
-{
-  const MetaOutputInfo *output_info = meta_output_get_info (output);
-
-  return round ((double) (hw_value - output_info->backlight_min) /
-                (output_info->backlight_max - output_info->backlight_min) * 100.0);
-}
-
-void
-meta_output_xrandr_change_backlight (MetaOutputXrandr *output_xrandr,
-                                     int               value)
-{
-  MetaOutput *output = META_OUTPUT (output_xrandr);
-  const MetaOutputInfo *output_info = meta_output_get_info (output);
-  Display *xdisplay = xdisplay_from_output (output);
-  Atom atom;
-  int hw_value;
-
-  hw_value = round ((double) value / 100.0 * output_info->backlight_max +
-                    output_info->backlight_min);
-
-  atom = XInternAtom (xdisplay, "Backlight", False);
-
-  xcb_randr_change_output_property (XGetXCBConnection (xdisplay),
-                                    (XID) meta_output_get_id (output),
-                                    atom, XCB_ATOM_INTEGER, 32,
-                                    XCB_PROP_MODE_REPLACE,
-                                    1, &hw_value);
-
-  /* We're not selecting for property notifies, so update the value immediately */
-  meta_output_set_backlight (output, normalize_backlight (output, hw_value));
-}
-
 static gboolean
 ctm_is_equal (const MetaOutputCtm *ctm1,
               const MetaOutputCtm *ctm2)
@@ -511,7 +476,6 @@ static int
 output_get_backlight_xrandr (MetaOutput *output)
 {
   Display *xdisplay = xdisplay_from_output (output);
-  int value = -1;
   Atom atom, actual_type;
   int actual_format;
   unsigned long nitems, bytes_after;
@@ -528,11 +492,23 @@ output_get_backlight_xrandr (MetaOutput *output)
   if (actual_type != XA_INTEGER || actual_format != 32 || nitems < 1)
     return FALSE;
 
-  value = ((int*)buffer)[0];
-  if (value > 0)
-    return normalize_backlight (output, value);
-  else
-    return -1;
+  return ((int *) buffer)[0];
+}
+
+static void
+on_backlight_changed (MetaOutput *output)
+{
+  Display *xdisplay = xdisplay_from_output (output);
+  int value = meta_output_get_backlight (output);
+  Atom atom;
+
+  atom = XInternAtom (xdisplay, "Backlight", False);
+
+  xcb_randr_change_output_property (XGetXCBConnection (xdisplay),
+                                    (XID) meta_output_get_id (output),
+                                    atom, XCB_ATOM_INTEGER, 32,
+                                    XCB_PROP_MODE_REPLACE,
+                                    1, &value);
 }
 
 static void
@@ -1061,7 +1037,11 @@ meta_output_xrandr_new (MetaGpuXrandr *gpu_xrandr,
     }
 
   if (!(output_info->backlight_min == 0 && output_info->backlight_max == 0))
-    meta_output_set_backlight (output, output_get_backlight_xrandr (output));
+    {
+      meta_output_set_backlight (output, output_get_backlight_xrandr (output));
+      g_signal_connect (output, "backlight-changed",  
+                        G_CALLBACK (on_backlight_changed), NULL);
+    }
 
   if (output_info->n_modes == 0 || output_info->n_possible_crtcs == 0)
     {

--- a/src/backends/x11/meta-output-xrandr.h
+++ b/src/backends/x11/meta-output-xrandr.h
@@ -36,9 +36,6 @@ G_DECLARE_FINAL_TYPE (MetaOutputXrandr, meta_output_xrandr,
 
 void meta_output_xrandr_apply_mode (MetaOutputXrandr *output_xrandr);
 
-void meta_output_xrandr_change_backlight (MetaOutputXrandr *output_xrandr,
-                                          int         value);
-
 void meta_output_xrandr_set_ctm (MetaOutputXrandr    *output_xrandr,
                                  const MetaOutputCtm *ctm);
 


### PR DESCRIPTION
This patch has been adapted from https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3861 Original author Jonas Ådahl
This is required to adapt to the GNOME-47 gnome-settings-daemon updates.  Without the patch gsd-power segfaults resulting with budgie exiting back to the login manager.

Marking as draft to complete testing and confirmation that there are no further commits to be incorporated from gitlab