### PR TITLE
GNOME 47 Scaling

### DIFF
--- a/data/dbus-interfaces/org.gnome.Mutter.X11.xml
+++ b/data/dbus-interfaces/org.gnome.Mutter.X11.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE node PUBLIC
+'-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
+'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
+<node>
+  <interface name="org.gnome.Mutter.X11">
+    <property name="UiScalingFactor" type="i" access="readwrite" />
+  </interface>
+</node>

--- a/src/meson.build
+++ b/src/meson.build
@@ -875,6 +875,13 @@ dbus_input_mapping_built_sources = gnome.gdbus_codegen('meta-dbus-input-mapping'
   )
 mutter_built_sources += dbus_input_mapping_built_sources
 
+dbus_x11_built_sources = gnome.gdbus_codegen('meta-dbus-x11',
+    join_paths(dbus_interfaces_dir, 'org.gnome.Mutter.X11.xml'),
+    interface_prefix: 'org.gnome.Mutter.',
+    namespace: 'MetaDBus',
+  )
+mutter_built_sources += dbus_x11_built_sources
+
 if have_profiler
   mutter_sources += [
     'core/meta-profiler.c',

--- a/src/x11/meta-x11-display.c
+++ b/src/x11/meta-x11-display.c
@@ -1382,7 +1382,7 @@ meta_x11_display_new (MetaDisplay  *display,
                            "monitors-changed-internal",
                            G_CALLBACK (on_monitors_changed_internal),
                            x11_display,
-                           0);
+                           G_CONNECT_AFTER);
 
   init_leader_window (x11_display, &timestamp);
   x11_display->timestamp = timestamp;
@@ -1914,6 +1914,8 @@ on_monitors_changed_internal (MetaMonitorManager *monitor_manager,
     }
 
   x11_display->has_xinerama_indices = FALSE;
+
+  update_ui_scaling_factor (x11_display);
 }
 
 void

--- a/src/x11/meta-x11-display.c
+++ b/src/x11/meta-x11-display.c
@@ -135,7 +135,6 @@ on_bus_acquired (GDBusConnection *connection,
                  const char      *name,
                  gpointer         user_data)
 {
-  g_warning("on_bus_acquired start");
   MetaX11Display *x11_display = user_data;
   MetaX11DisplayPrivate *priv =
     meta_x11_display_get_instance_private (x11_display);
@@ -144,13 +143,11 @@ on_bus_acquired (GDBusConnection *connection,
                                     connection,
                                     "/org/gnome/Mutter/X11",
                                     NULL);
-  g_warning("on_bus_acquired end");
 }
 
 static void
 update_ui_scaling_factor (MetaX11Display *x11_display)
 {
-  g_warning("update_ui_scaling_factor start");
   MetaX11DisplayPrivate *priv =
     meta_x11_display_get_instance_private (x11_display);
   MetaBackend *backend = backend_from_x11_display (x11_display);
@@ -181,7 +178,6 @@ update_ui_scaling_factor (MetaX11Display *x11_display)
     }
 
   meta_dbus_x11_set_ui_scaling_factor (priv->dbus_api, ui_scaling_factor);
-  g_warning("update_ui_scaling_factor emd");
 }
 
 static void
@@ -1191,7 +1187,6 @@ on_window_visibility_updated (MetaDisplay    *display,
 static void
 initialize_dbus_interface (MetaX11Display *x11_display)
 {
-  g_warning("initialize_dbus_interface start");
   MetaX11DisplayPrivate *priv =
     meta_x11_display_get_instance_private (x11_display);
 
@@ -1204,7 +1199,6 @@ initialize_dbus_interface (MetaX11Display *x11_display)
                     NULL, NULL,
                     x11_display, NULL);
   update_ui_scaling_factor (x11_display);
-  g_warning("initialize_dbus_interface end");
 }
 
 /**
@@ -1239,9 +1233,7 @@ meta_x11_display_new (MetaDisplay  *display,
   MetaBackend *backend = meta_get_backend ();
   MetaMonitorManager *monitor_manager =
     meta_backend_get_monitor_manager (backend);
-  g_warning("aaaaa");
   MetaSettings *settings = meta_backend_get_settings (backend);
-  g_warning("bbbb");
   /* A list of all atom names, so that we can intern them in one go. */
   const char *atom_names[] = {
 #define item(x) #x,
@@ -1310,9 +1302,7 @@ meta_x11_display_new (MetaDisplay  *display,
   x11_display = g_object_new (META_TYPE_X11_DISPLAY, NULL);
   x11_display->gdk_display = gdk_display;
   x11_display->display = display;
-  g_warning("1");
   initialize_dbus_interface (x11_display);
-  g_warning("2");
 
   /* here we use XDisplayName which is what the user
    * probably put in, vs. DisplayString(display) which is


### PR DESCRIPTION
This is a truncated version of https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/3567/diffs that ensures gnome-settings-daemon xsettings has something to chew on.

It creates a dbus interface for GSD to obtain scaling info.

magpie itself responds to monitors signal changes to configure the UI scaling factor.

I've given this a preliminary look-see in a virtualbox session scaling between 100%, 200% and 300% and the scaling survives logout and login.

Well worth retesting with multimonitors etc.